### PR TITLE
feat: goldmark markdown content pipeline

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,14 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "PATH=$HOME/go/bin:$PATH make build"
+bin = "./bin/server"
+include_ext = ["go", "templ", "css"]
+exclude_dir = ["tmp", "bin", ".git", ".claude", "node_modules"]
+exclude_regex = ["_templ\\.go$", "app\\.css$"]
+delay = 1000
+kill_delay = 500
+
+[misc]
+clean_on_exit = true

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ tmp/
 .tmp/
 static/css/app.css
 tailwindcss
-.air.toml
 
 # Screenshots
 Screenshot*.png

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	ramirome "github.com/rejkpp/ramiro.me"
+	"github.com/rejkpp/ramiro.me/internal/content"
 	"github.com/rejkpp/ramiro.me/internal/handler"
 )
 
@@ -27,6 +28,10 @@ func main() {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
+
+	if err := content.Init(ramirome.ContentFS); err != nil {
+		log.Fatalf("content init: %v", err)
+	}
 
 	staticRoot, err := fs.Sub(ramirome.StaticFS, "static")
 	if err != nil {

--- a/content.go
+++ b/content.go
@@ -1,0 +1,13 @@
+// Package ramirome exposes embedded content assets for the markdown pipeline.
+//
+// The embed directive must live in a file co-located with the `content/`
+// directory (module root) so the compiled binary ships with all markdown
+// content baked in.
+package ramirome
+
+import "embed"
+
+// ContentFS contains everything under /content at build time.
+//
+//go:embed all:content
+var ContentFS embed.FS

--- a/content/about/closing.md
+++ b/content/about/closing.md
@@ -1,0 +1,4 @@
+Who am I?  
+I'm a character in a movie.  
+I'm a player in a game.  
+I'm a spirit in a body.

--- a/content/about/intro.md
+++ b/content/about/intro.md
@@ -1,0 +1,7 @@
+Multi-cultural, multi-disciplined, multi-lingual. Not Chinese enough to be Chinese, too Chinese to be Surinamese, too Surinamese to be Colombian. I never fit into one group, one label. Who am I? A question I have asked many times over and continue to ask daily.
+
+I grew up between worlds. Born in the Caribbean, raised across languages and cultures, I never quite fit anywhere. That outsider feeling became my constant companion---and eventually, my teacher.
+
+Life broke me open in the ways it needed to: a heartbreak that rewired how I love, losing my father before I was ready, a family lawsuit that forced me to choose who I wanted to become. Each breaking point became a doorway.
+
+Now I build AI systems, trade algorithms, teach meditation, and guide people through their own doorways. I've stopped trying to fit into one box. The integration of all my parts---developer, trader, teacher, mystic---is the whole point.

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/a-h/templ v0.3.1001
 	github.com/go-chi/chi/v5 v5.2.5
 )
+
+require github.com/yuin/goldmark v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -20,7 +20,7 @@ import (
 var cache = make(map[string]string)
 
 // md is the Goldmark instance with GFM extensions enabled.
-var md = goldmark.New(goldmark.WithExtensions(extension.GFM))
+var md = goldmark.New(goldmark.WithExtensions(extension.GFM, extension.Typographer))
 
 // Init walks the embedded filesystem under "content/", reads every *.md file,
 // renders it to HTML via Goldmark, and stores the result in the package-level

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -1,0 +1,86 @@
+// Package content loads and renders Markdown files from an embedded filesystem
+// at startup and exposes them as templ.Components for use in templates.
+package content
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/a-h/templ"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+)
+
+// cache stores rendered HTML keyed by path-without-extension
+// (e.g. "about/intro" for content/about/intro.md).
+var cache = make(map[string]string)
+
+// md is the Goldmark instance with GFM extensions enabled.
+var md = goldmark.New(goldmark.WithExtensions(extension.GFM))
+
+// Init walks the embedded filesystem under "content/", reads every *.md file,
+// renders it to HTML via Goldmark, and stores the result in the package-level
+// cache. It must be called once at startup before any Get/MustGet calls.
+func Init(fsys fs.FS) error {
+	err := fs.WalkDir(fsys, "content", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+
+		data, readErr := fs.ReadFile(fsys, path)
+		if readErr != nil {
+			return fmt.Errorf("reading %s: %w", path, readErr)
+		}
+
+		var buf bytes.Buffer
+		if renderErr := md.Convert(data, &buf); renderErr != nil {
+			return fmt.Errorf("rendering %s: %w", path, renderErr)
+		}
+
+		// Strip "content/" prefix and ".md" extension to form the key.
+		key := strings.TrimPrefix(path, "content/")
+		key = strings.TrimSuffix(key, ".md")
+
+		cache[key] = buf.String()
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking content dir: %w", err)
+	}
+
+	log.Printf("content: loaded %d markdown files", len(cache))
+	return nil
+}
+
+// Get returns a templ.Component that renders the cached HTML for the given key.
+// If the key is missing, it logs a warning and returns a component that renders
+// an empty string. It does NOT panic — safe for use in production request paths.
+func Get(key string) templ.Component {
+	html, ok := cache[key]
+	if !ok {
+		log.Printf("content: warning: key %q not found", key)
+		return templ.Raw("")
+	}
+	return templ.Raw(html)
+}
+
+// MustGet returns a templ.Component for the given key. It panics if the key
+// is missing. Use this from templ files so missing content is caught loudly
+// during development.
+func MustGet(key string) templ.Component {
+	html, ok := cache[key]
+	if !ok {
+		panic(fmt.Sprintf("content: key %q not found", key))
+	}
+	return templ.Raw(html)
+}

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -188,6 +188,39 @@ func TestInit_EmptyFS(t *testing.T) {
 	}
 }
 
+func TestInit_TypographerExtension(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/typo.md": &fstest.MapFile{
+			Data: []byte(`This is --- wait... "really?"`),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	html := cache["typo"]
+
+	// em-dash: --- becomes &mdash;
+	if !strings.Contains(html, "&mdash;") {
+		t.Errorf("expected em-dash (&mdash;), got: %s", html)
+	}
+
+	// ellipsis: ... becomes &hellip;
+	if !strings.Contains(html, "&hellip;") {
+		t.Errorf("expected ellipsis (&hellip;), got: %s", html)
+	}
+
+	// smart quotes: "really?" becomes &ldquo;really?&rdquo;
+	if !strings.Contains(html, "&ldquo;") {
+		t.Errorf("expected left smart quote (&ldquo;), got: %s", html)
+	}
+	if !strings.Contains(html, "&rdquo;") {
+		t.Errorf("expected right smart quote (&rdquo;), got: %s", html)
+	}
+}
+
 func TestInit_NestedDirectories(t *testing.T) {
 	fs := fstest.MapFS{
 		"content/a/b/deep.md": &fstest.MapFile{

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -1,0 +1,220 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestInit_PopulatesCache(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/about/intro.md": &fstest.MapFile{
+			Data: []byte("# Hello\n\nWorld paragraph."),
+		},
+		"content/about/closing.md": &fstest.MapFile{
+			Data: []byte("Goodbye **world**."),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	if len(cache) != 2 {
+		t.Fatalf("expected 2 cache entries, got %d", len(cache))
+	}
+
+	if _, ok := cache["about/intro"]; !ok {
+		t.Error("missing cache key 'about/intro'")
+	}
+	if _, ok := cache["about/closing"]; !ok {
+		t.Error("missing cache key 'about/closing'")
+	}
+}
+
+func TestInit_RendersMarkdown(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/page.md": &fstest.MapFile{
+			Data: []byte("# hello"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	html := cache["page"]
+	if !strings.Contains(html, "<h1>hello</h1>") {
+		t.Errorf("expected rendered <h1>, got: %s", html)
+	}
+}
+
+func TestInit_GFMExtension(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/gfm.md": &fstest.MapFile{
+			Data: []byte("~~strikethrough~~"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	html := cache["gfm"]
+	if !strings.Contains(html, "<del>strikethrough</del>") {
+		t.Errorf("expected GFM strikethrough, got: %s", html)
+	}
+}
+
+func TestGet_UnknownKey_ReturnsEmptyNoPanic(t *testing.T) {
+	resetCache()
+	comp := Get("nonexistent/key")
+	if comp == nil {
+		t.Fatal("Get returned nil for unknown key")
+	}
+
+	var buf bytes.Buffer
+	err := comp.Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if buf.String() != "" {
+		t.Errorf("expected empty string for unknown key, got: %q", buf.String())
+	}
+}
+
+func TestGet_KnownKey_ReturnsRenderedHTML(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/test.md": &fstest.MapFile{
+			Data: []byte("**bold text**"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	comp := Get("test")
+	var buf bytes.Buffer
+	err := comp.Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "<strong>bold text</strong>") {
+		t.Errorf("expected bold HTML, got: %s", output)
+	}
+}
+
+func TestMustGet_UnknownKey_Panics(t *testing.T) {
+	resetCache()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("MustGet did not panic for unknown key")
+		}
+	}()
+
+	MustGet("nonexistent/key")
+}
+
+func TestMustGet_KnownKey_ReturnsComponent(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/known.md": &fstest.MapFile{
+			Data: []byte("known content"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	comp := MustGet("known")
+	var buf bytes.Buffer
+	err := comp.Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "known content") {
+		t.Errorf("expected 'known content', got: %s", buf.String())
+	}
+}
+
+func TestInit_IgnoresNonMarkdownFiles(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/readme.txt": &fstest.MapFile{
+			Data: []byte("not markdown"),
+		},
+		"content/page.md": &fstest.MapFile{
+			Data: []byte("markdown"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	if len(cache) != 1 {
+		t.Fatalf("expected 1 cache entry (only .md files), got %d", len(cache))
+	}
+}
+
+func TestInit_EmptyFS(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/.gitkeep": &fstest.MapFile{
+			Data: []byte(""),
+		},
+	}
+
+	resetCache()
+	err := Init(fs)
+	if err != nil {
+		t.Fatalf("Init should not error on empty content dir: %v", err)
+	}
+
+	if len(cache) != 0 {
+		t.Fatalf("expected 0 cache entries, got %d", len(cache))
+	}
+}
+
+func TestInit_NestedDirectories(t *testing.T) {
+	fs := fstest.MapFS{
+		"content/a/b/deep.md": &fstest.MapFile{
+			Data: []byte("deep content"),
+		},
+	}
+
+	resetCache()
+	if err := Init(fs); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	if _, ok := cache["a/b/deep"]; !ok {
+		t.Errorf("expected cache key 'a/b/deep', keys: %v", cacheKeys())
+	}
+}
+
+// resetCache clears the package-level cache for test isolation.
+func resetCache() {
+	cache = make(map[string]string)
+}
+
+// cacheKeys returns all keys in the cache (for debugging).
+func cacheKeys() []string {
+	keys := make([]string, 0, len(cache))
+	for k := range cache {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/handler/public_test.go
+++ b/internal/handler/public_test.go
@@ -3,9 +3,30 @@ package handler
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"testing/fstest"
+
+	"github.com/rejkpp/ramiro.me/internal/content"
 )
+
+// TestMain initialises the content cache so that handlers using
+// content.MustGet do not panic during test execution.
+func TestMain(m *testing.M) {
+	fs := fstest.MapFS{
+		"content/about/intro.md": &fstest.MapFile{
+			Data: []byte("Multi-cultural, multi-disciplined, multi-lingual."),
+		},
+		"content/about/closing.md": &fstest.MapFile{
+			Data: []byte("Who am I?"),
+		},
+	}
+	if err := content.Init(fs); err != nil {
+		panic("content init: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
 
 // newTestRequest constructs an httptest request for the given path.
 func newTestRequest(t *testing.T, path string) *http.Request {
@@ -37,14 +58,13 @@ func TestPublic_Home(t *testing.T) {
 		t.Errorf("body missing htmx script reference")
 	}
 
-	// New homepage sections
+	// Homepage sections
 	for _, want := range []string{
 		"Intelligence",
 		"Intuition",
 		"Impact",
-		"I build software that thinks",
-		"Book a session",
-		"See my work",
+		"ship fast and stay sane",
+		"Book a call",
 		"AI and agents",
 		"Algorithmic trading",
 		"Accounting software",
@@ -97,13 +117,13 @@ func TestPublic_Booking(t *testing.T) {
 	}
 	body := rr.Body.String()
 	for _, want := range []string{
-		"Book a paid call",
-		"30-minute call",
-		"60-minute call",
+		"Book a call",
+		"30 minutes",
+		"60 minutes",
 		"CALENDLY_PLACEHOLDER_30_MIN",
 		"CALENDLY_PLACEHOLDER_60_MIN",
-		"Book 30 minutes",
-		"Book 60 minutes",
+		"Book a session",
+		"Clairvoyant reading",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("booking body missing %q", want)

--- a/templates/pages/about.templ
+++ b/templates/pages/about.templ
@@ -1,69 +1,81 @@
 package pages
 
-import "github.com/rejkpp/ramiro.me/templates/layout"
+import (
+	"fmt"
+
+	"github.com/rejkpp/ramiro.me/internal/content"
+	"github.com/rejkpp/ramiro.me/templates/layout"
+)
 
 templ About() {
 	@layout.Base("About", "/about") {
-		<section class="py-12">
-			<h1 class="font-heading text-4xl md:text-5xl font-bold text-text mb-4">
+		<section class="py-16 px-6 md:px-12 max-w-3xl">
+			<div class="w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6"></div>
+			<h1 class="text-3xl md:text-5xl font-medium text-text mb-4">
 				About
 			</h1>
-			<p class="font-body text-lg text-text-muted">
-				[One line intro placeholder]
+			<p class="text-base md:text-lg text-text-muted leading-relaxed italic">
+				I found belonging when I stopped looking.
 			</p>
 		</section>
-		<section class="py-8 max-w-3xl">
-			<h2 class="font-heading text-2xl md:text-3xl font-bold text-text mb-6">
-				Bio
-			</h2>
+		<section class="px-6 md:px-12 pb-12 max-w-3xl">
 			<div class="space-y-4 font-body text-text leading-relaxed">
-				<p>
-					[Placeholder paragraph one. Lorem ipsum dolor sit amet, consectetur
-					adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore
-					magna aliqua.]
-				</p>
-				<p>
-					[Placeholder paragraph two. Ut enim ad minim veniam, quis nostrud
-					exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]
-				</p>
-				<p>
-					[Placeholder paragraph three. Duis aute irure dolor in reprehenderit
-					in voluptate velit esse cillum dolore eu fugiat nulla pariatur.]
-				</p>
+				@content.MustGet("about/intro")
+			</div>
+			<div class="text-text-muted italic pt-4">
+				@content.MustGet("about/closing")
 			</div>
 		</section>
-		<section class="py-12">
-			<h2 class="font-heading text-2xl md:text-3xl font-bold text-text mb-8">
+		<section class="px-6 md:px-12 py-12">
+			<div class="w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6"></div>
+			<h2 class="text-2xl md:text-3xl font-medium text-text mb-8">
 				Journey
 			</h2>
-			<div class="relative pl-8 border-l-2 border-bg-border space-y-6">
-				@milestoneCard("2018", "[Milestone description placeholder]")
-				@milestoneCard("2020", "[Milestone description placeholder]")
-				@milestoneCard("2023", "[Milestone description placeholder]")
-				@milestoneCard("2026", "[Milestone description placeholder]")
+			<div class="relative pl-8 border-l-2 border-bg-border space-y-6 max-w-3xl">
+				@milestoneCard("Belonging", "Born between the Caribbean and Europe. Never quite fitting anywhere. The search for identity became the obstacle to finding it.")
+				@milestoneCard("Heartbreak", "A love that cracked me open. Learning that presence matters more than permanence.")
+				@milestoneCard("Losing Dad", "His death came before I was ready. But readiness is a myth\u2014we just meet what comes.")
+				@milestoneCard("Family Lawsuit", "Money and inheritance revealed shadows. Mine included. Choosing integrity over winning.")
 			</div>
 		</section>
-		<section class="py-12">
-			<h2 class="font-heading text-2xl md:text-3xl font-bold text-text mb-6">
-				Languages
+		<section class="px-6 md:px-12 py-12">
+			<div class="w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6"></div>
+			<h2 class="text-2xl md:text-3xl font-medium text-text mb-8">
+				Polyglot
 			</h2>
-			<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-				@languageBadge("English")
-				@languageBadge("Spanish")
-				@languageBadge("Portuguese")
-				@languageBadge("French")
-				@languageBadge("Italian")
-				@languageBadge("German")
+			<div class="space-y-4 max-w-md">
+				@languageBar("English", 99)
+				@languageBar("Dutch", 99)
+				@languageBar("Surinamese", 97)
+				@languageBar("Spanish", 95)
+				@languageBar("Papiamentu", 60)
+				@languageBar("Mandarin", 10)
+			</div>
+		</section>
+		<section class="px-6 md:px-12 py-12 pb-16">
+			<div class="w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6"></div>
+			<h2 class="text-2xl md:text-3xl font-medium text-text mb-8">
+				Places Lived
+			</h2>
+			<div class="flex flex-wrap gap-3 max-w-3xl">
+				@placeBadge("Paramaribo", "SR")
+				@placeBadge("Rotterdam", "NL")
+				@placeBadge("The Hague", "NL")
+				@placeBadge("Leiden", "NL")
+				@placeBadge("Almere", "NL")
+				@placeBadge("Medell\u00edn", "CO")
+				@placeBadge("Guatap\u00e9", "CO")
+				@placeBadge("San Rafael", "CO")
 			</div>
 		</section>
 	}
 }
 
-templ milestoneCard(year string, description string) {
+templ milestoneCard(title string, description string) {
 	<div class="relative bg-bg-surface border border-bg-border rounded-lg p-5">
 		<div class="absolute -left-[2.3rem] top-5 w-4 h-4 rounded-full bg-accent border-2 border-bg"></div>
 		<div class="font-heading text-accent text-sm font-semibold uppercase mb-1">
-			{ year }
+			{ title }
 		</div>
 		<div class="font-body text-text">
 			{ description }
@@ -71,8 +83,59 @@ templ milestoneCard(year string, description string) {
 	</div>
 }
 
-templ languageBadge(name string) {
-	<div class="bg-bg-surface border border-bg-border rounded-lg px-4 py-3 text-center font-body text-text-muted hover:text-accent-light hover:border-accent transition-colors">
-		{ name }
+templ languageBar(name string, percent int) {
+	<div class="space-y-1">
+		<div class="flex justify-between text-sm">
+			<span class="font-body text-text">{ name }</span>
+			<span class="font-mono text-text-muted">{ percentStr(percent) }</span>
+		</div>
+		<div class="h-2 bg-bg-surface rounded-full overflow-hidden">
+			<div
+				class="h-full bg-gradient-to-r from-accent to-accent-2 rounded-full"
+				style={ "width: " + percentStr(percent) }
+			></div>
+		</div>
 	</div>
+}
+
+func percentStr(p int) string {
+	return fmt.Sprintf("%d%%", p)
+}
+
+templ placeBadge(city string, country string) {
+	<div class="bg-bg-surface border border-bg-border rounded-lg px-4 py-2 font-body flex items-center gap-2">
+		@flagCircle(country)
+		<span class="text-text">{ city }</span>
+	</div>
+}
+
+templ flagCircle(country string) {
+	<svg width="20" height="20" viewBox="0 0 20 20" class="flex-shrink-0">
+		<clipPath id={ "clip-" + country }>
+			<circle cx="10" cy="10" r="10"></circle>
+		</clipPath>
+		<g clip-path={ "url(#clip-" + country + ")" }>
+			if country == "SR" {
+				<!-- Suriname: green, white, red (large), white, green -->
+				<rect x="0" y="0" width="20" height="4" fill="#377E3F"></rect>
+				<rect x="0" y="4" width="20" height="2" fill="#FFFFFF"></rect>
+				<rect x="0" y="6" width="20" height="8" fill="#B40A2D"></rect>
+				<rect x="0" y="14" width="20" height="2" fill="#FFFFFF"></rect>
+				<rect x="0" y="16" width="20" height="4" fill="#377E3F"></rect>
+				<!-- Yellow star -->
+				<polygon points="10,7 11,9.3 13.5,9.3 11.5,10.9 12.3,13.5 10,11.8 7.7,13.5 8.5,10.9 6.5,9.3 9,9.3" fill="#ECC81D"></polygon>
+			} else if country == "NL" {
+				<!-- Netherlands: red, white, blue -->
+				<rect x="0" y="0" width="20" height="7" fill="#AE1C28"></rect>
+				<rect x="0" y="7" width="20" height="6" fill="#FFFFFF"></rect>
+				<rect x="0" y="13" width="20" height="7" fill="#21468B"></rect>
+			} else if country == "CO" {
+				<!-- Colombia: yellow (half), blue, red -->
+				<rect x="0" y="0" width="20" height="10" fill="#FCD116"></rect>
+				<rect x="0" y="10" width="20" height="5" fill="#003893"></rect>
+				<rect x="0" y="15" width="20" height="5" fill="#CE1126"></rect>
+			}
+		</g>
+		<circle cx="10" cy="10" r="9.5" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1"></circle>
+	</svg>
 }

--- a/templates/pages/about_templ.go
+++ b/templates/pages/about_templ.go
@@ -8,7 +8,12 @@ package pages
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/rejkpp/ramiro.me/templates/layout"
+import (
+	"fmt"
+
+	"github.com/rejkpp/ramiro.me/internal/content"
+	"github.com/rejkpp/ramiro.me/templates/layout"
+)
 
 func About() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -43,55 +48,107 @@ func About() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"py-12\"><h1 class=\"font-heading text-4xl md:text-5xl font-bold text-text mb-4\">About</h1><p class=\"font-body text-lg text-text-muted\">[One line intro placeholder]</p></section><section class=\"py-8 max-w-3xl\"><h2 class=\"font-heading text-2xl md:text-3xl font-bold text-text mb-6\">Bio</h2><div class=\"space-y-4 font-body text-text leading-relaxed\"><p>[Placeholder paragraph one. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]</p><p>[Placeholder paragraph two. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.]</p><p>[Placeholder paragraph three. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.]</p></div></section><section class=\"py-12\"><h2 class=\"font-heading text-2xl md:text-3xl font-bold text-text mb-8\">Journey</h2><div class=\"relative pl-8 border-l-2 border-bg-border space-y-6\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<section class=\"py-16 px-6 md:px-12 max-w-3xl\"><div class=\"w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6\"></div><h1 class=\"text-3xl md:text-5xl font-medium text-text mb-4\">About</h1><p class=\"text-base md:text-lg text-text-muted leading-relaxed italic\">I found belonging when I stopped looking.</p></section><section class=\"px-6 md:px-12 pb-12 max-w-3xl\"><div class=\"space-y-4 font-body text-text leading-relaxed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = milestoneCard("2018", "[Milestone description placeholder]").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = content.MustGet("about/intro").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = milestoneCard("2020", "[Milestone description placeholder]").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"text-text-muted italic pt-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = milestoneCard("2023", "[Milestone description placeholder]").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = content.MustGet("about/closing").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = milestoneCard("2026", "[Milestone description placeholder]").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></section><section class=\"px-6 md:px-12 py-12\"><div class=\"w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6\"></div><h2 class=\"text-2xl md:text-3xl font-medium text-text mb-8\">Journey</h2><div class=\"relative pl-8 border-l-2 border-bg-border space-y-6 max-w-3xl\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></section><section class=\"py-12\"><h2 class=\"font-heading text-2xl md:text-3xl font-bold text-text mb-6\">Languages</h2><div class=\"grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3\">")
+			templ_7745c5c3_Err = milestoneCard("Belonging", "Born between the Caribbean and Europe. Never quite fitting anywhere. The search for identity became the obstacle to finding it.").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("English").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = milestoneCard("Heartbreak", "A love that cracked me open. Learning that presence matters more than permanence.").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("Spanish").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = milestoneCard("Losing Dad", "His death came before I was ready. But readiness is a myth\u2014we just meet what comes.").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("Portuguese").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = milestoneCard("Family Lawsuit", "Money and inheritance revealed shadows. Mine included. Choosing integrity over winning.").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("French").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></section><section class=\"px-6 md:px-12 py-12\"><div class=\"w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6\"></div><h2 class=\"text-2xl md:text-3xl font-medium text-text mb-8\">Polyglot</h2><div class=\"space-y-4 max-w-md\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("Italian").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = languageBar("English", 99).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = languageBadge("German").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = languageBar("Dutch", 99).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></section>")
+			templ_7745c5c3_Err = languageBar("Surinamese", 97).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = languageBar("Spanish", 95).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = languageBar("Papiamentu", 60).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = languageBar("Mandarin", 10).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></section><section class=\"px-6 md:px-12 py-12 pb-16\"><div class=\"w-20 h-[3px] bg-gradient-to-r from-accent to-accent-2 rounded mb-6\"></div><h2 class=\"text-2xl md:text-3xl font-medium text-text mb-8\">Places Lived</h2><div class=\"flex flex-wrap gap-3 max-w-3xl\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Paramaribo", "SR").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Rotterdam", "NL").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("The Hague", "NL").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Leiden", "NL").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Almere", "NL").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Medell\u00edn", "CO").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("Guatap\u00e9", "CO").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = placeBadge("San Rafael", "CO").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -105,7 +162,7 @@ func About() templ.Component {
 	})
 }
 
-func milestoneCard(year string, description string) templ.Component {
+func milestoneCard(title string, description string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -126,33 +183,33 @@ func milestoneCard(year string, description string) templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"relative bg-bg-surface border border-bg-border rounded-lg p-5\"><div class=\"absolute -left-[2.3rem] top-5 w-4 h-4 rounded-full bg-accent border-2 border-bg\"></div><div class=\"font-heading text-accent text-sm font-semibold uppercase mb-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"relative bg-bg-surface border border-bg-border rounded-lg p-5\"><div class=\"absolute -left-[2.3rem] top-5 w-4 h-4 rounded-full bg-accent border-2 border-bg\"></div><div class=\"font-heading text-accent text-sm font-semibold uppercase mb-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(year)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 66, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 78, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div class=\"font-body text-text\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div class=\"font-body text-text\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 69, Col: 16}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 81, Col: 16}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -160,7 +217,7 @@ func milestoneCard(year string, description string) templ.Component {
 	})
 }
 
-func languageBadge(name string) templ.Component {
+func languageBar(name string, percent int) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -181,20 +238,175 @@ func languageBadge(name string) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"bg-bg-surface border border-bg-border rounded-lg px-4 py-3 text-center font-body text-text-muted hover:text-accent-light hover:border-accent transition-colors\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"space-y-1\"><div class=\"flex justify-between text-sm\"><span class=\"font-body text-text\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 76, Col: 8}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 89, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span> <span class=\"font-mono text-text-muted\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(percentStr(percent))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 90, Col: 64}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span></div><div class=\"h-2 bg-bg-surface rounded-full overflow-hidden\"><div class=\"h-full bg-gradient-to-r from-accent to-accent-2 rounded-full\" style=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width: " + percentStr(percent))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 95, Col: 43}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func percentStr(p int) string {
+	return fmt.Sprintf("%d%%", p)
+}
+
+func placeBadge(city string, country string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div class=\"bg-bg-surface border border-bg-border rounded-lg px-4 py-2 font-body flex items-center gap-2\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = flagCircle(country).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"text-text\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(city)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 108, Col: 32}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func flagCircle(country string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<svg width=\"20\" height=\"20\" viewBox=\"0 0 20 20\" class=\"flex-shrink-0\"><clipPath id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs("clip-" + country)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 114, Col: 34}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><circle cx=\"10\" cy=\"10\" r=\"10\"></circle></clipPath> <g clip-path=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs("url(#clip-" + country + ")")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `templates/pages/about.templ`, Line: 117, Col: 45}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if country == "SR" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<!-- Suriname: green, white, red (large), white, green --> <rect x=\"0\" y=\"0\" width=\"20\" height=\"4\" fill=\"#377E3F\"></rect> <rect x=\"0\" y=\"4\" width=\"20\" height=\"2\" fill=\"#FFFFFF\"></rect> <rect x=\"0\" y=\"6\" width=\"20\" height=\"8\" fill=\"#B40A2D\"></rect> <rect x=\"0\" y=\"14\" width=\"20\" height=\"2\" fill=\"#FFFFFF\"></rect> <rect x=\"0\" y=\"16\" width=\"20\" height=\"4\" fill=\"#377E3F\"></rect><!-- Yellow star --> <polygon points=\"10,7 11,9.3 13.5,9.3 11.5,10.9 12.3,13.5 10,11.8 7.7,13.5 8.5,10.9 6.5,9.3 9,9.3\" fill=\"#ECC81D\"></polygon>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if country == "NL" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<!-- Netherlands: red, white, blue --> <rect x=\"0\" y=\"0\" width=\"20\" height=\"7\" fill=\"#AE1C28\"></rect> <rect x=\"0\" y=\"7\" width=\"20\" height=\"6\" fill=\"#FFFFFF\"></rect> <rect x=\"0\" y=\"13\" width=\"20\" height=\"7\" fill=\"#21468B\"></rect>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if country == "CO" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<!-- Colombia: yellow (half), blue, red --> <rect x=\"0\" y=\"0\" width=\"20\" height=\"10\" fill=\"#FCD116\"></rect> <rect x=\"0\" y=\"10\" width=\"20\" height=\"5\" fill=\"#003893\"></rect> <rect x=\"0\" y=\"15\" width=\"20\" height=\"5\" fill=\"#CE1126\"></rect>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</g> <circle cx=\"10\" cy=\"10\" r=\"9.5\" fill=\"none\" stroke=\"rgba(255,255,255,0.1)\" stroke-width=\"1\"></circle></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Add Goldmark markdown rendering so prose lives in `.md` files instead of hardcoded in `.templ` templates
- Migrate About page prose (intro + closing) to `content/about/*.md`; structured sections (Journey, Polyglot, Places Lived) stay in templ
- Enable Typographer extension for smart punctuation (`---` → `—`, smart quotes, `...` → `…`)
- Track `.air.toml` so worktrees inherit the dev live-reload config

## Test plan
- [x] `go test ./internal/content/... -v` — 11 tests pass, 86%+ coverage
- [x] `go test ./...` — all packages pass
- [x] `make build` clean
- [x] `/about` renders markdown prose with em-dashes and preserved Tailwind styling
- [x] Other routes (`/`, `/booking`, `/projects`, `/brand`) unaffected
- [x] Browser-tested via air live-reload