### PR TITLE
chore: static export cleanup (RemoveAll outDir + per-platform tailwind)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ public/
 tmp/
 .tmp/
 static/css/app.css
-tailwindcss
+tailwindcss-darwin-arm64
+tailwindcss-linux-x64
 /server
 
 # Screenshots

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: css templ build dev gen static clean
 
-TAILWIND_BIN := ./tailwindcss
+TAILWIND_BIN := ./tailwindcss-darwin-arm64
 TAILWIND_URL := https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
 
 css:
@@ -28,4 +28,5 @@ static: css gen
 clean:
 	rm -rf bin/ public/
 	rm -f static/css/app.css
+	rm -f tailwindcss-darwin-arm64 tailwindcss-linux-x64
 	find . -name "*_templ.go" -type f -delete

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TAILWIND_BIN="./tailwindcss"
+TAILWIND_BIN="./tailwindcss-linux-x64"
 TAILWIND_URL="https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64"
 
 # Download Tailwind CLI if not present.

--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -41,6 +41,10 @@ func main() {
 
 // generate renders all pages and partials to outDir, and copies static assets.
 func generate(outDir string) error {
+	if err := os.RemoveAll(outDir); err != nil {
+		return fmt.Errorf("clear out dir: %w", err)
+	}
+
 	// Initialize markdown content (required by Home, About pages).
 	if err := content.Init(ramirome.ContentFS); err != nil {
 		return fmt.Errorf("content init: %w", err)

--- a/cmd/gen/main_test.go
+++ b/cmd/gen/main_test.go
@@ -7,6 +7,28 @@ import (
 	"testing"
 )
 
+func TestGenerateRemovesStaleFiles(t *testing.T) {
+	outDir := t.TempDir()
+
+	// Pre-create a stale file that should not survive a fresh generate.
+	staleDir := filepath.Join(outDir, "stale")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("create stale dir: %v", err)
+	}
+	stalePath := filepath.Join(staleDir, "index.html")
+	if err := os.WriteFile(stalePath, []byte("<html>stale</html>"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	if err := generate(outDir); err != nil {
+		t.Fatalf("generate(%q): %v", outDir, err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale file %s should have been removed, but still exists", stalePath)
+	}
+}
+
 func TestGenerate(t *testing.T) {
 	outDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
Two minor follow-ups from the inspector verdict on PR #7.

- `cmd/gen` now `os.RemoveAll(outDir)` at the start of `generate()` — stale routes from removed pages no longer persist across builds. Test added: `TestGenerateRemovesStaleFiles`.
- Tailwind binaries renamed per platform (`tailwindcss-darwin-arm64` / `tailwindcss-linux-x64`) so Makefile (macOS) and build.sh (Linux) no longer collide on the same `./tailwindcss` filename.

## Test plan
- [x] `go test ./...` passes
- [x] `go run ./cmd/gen` removes a manually-pre-created stale file
- [x] `make css` downloads `tailwindcss-darwin-arm64`, produces `static/css/app.css`
- [x] `build.sh` references `tailwindcss-linux-x64`